### PR TITLE
2I - Update merge_index to accept 'undefined' on either end of a range query (AZ459)

### DIFF
--- a/src/mi_buffer.erl
+++ b/src/mi_buffer.erl
@@ -157,12 +157,13 @@ add_field_term(_Field, _Term, Props) ->
 
 
 %% @private
-%% @spec gen_filter(Index::binary(), Field::term(), StartTerm::term(), EndTerm::term(), Size::all|integer()) -> 
-%%           function().
-%%
 %% @doc Given and Index, Field, StartTerm, EndTerm, and Size, return a
 %%      filter function that returns true if the provided Key (of
 %%      format {Index, Field, Term}) is within the acceptable range.
+-spec gen_filter(merge_index:index(), merge_index:field(), 
+                 merge_index:mi_term(), merge_index:mi_term(), 
+                 merge_index:size()) -> 
+                        fun((merge_index:index(), merge_index:field(), merge_index:term()) -> boolean()).
 gen_filter(Index, Field, StartTerm, EndTerm, Size) ->
     %% Construct a function to check start bounds...
     StartFun = case StartTerm of

--- a/src/mi_buffer.erl
+++ b/src/mi_buffer.erl
@@ -155,31 +155,45 @@ add_field_term(Field, Term, Props) when is_list(Props) ->
 add_field_term(_Field, _Term, Props) ->
     Props.
 
+
+%% @private
+%% @spec gen_filter(Index::binary(), Field::term(), StartTerm::term(), EndTerm::term(), Size::all|integer()) -> 
+%%           function().
+%%
+%% @doc Given and Index, Field, StartTerm, EndTerm, and Size, return a
+%%      filter function that returns true if the provided Key (of
+%%      format {Index, Field, Term}) is within the acceptable range.
 gen_filter(Index, Field, StartTerm, EndTerm, Size) ->
-    case EndTerm of
-        undefined ->
-            case Size of
-                all ->
-                    fun(Key) -> Key >= {Index, Field, StartTerm} end;
-                _ ->
-                    fun(Key) -> Key >= {Index, Field, StartTerm}
-                                    andalso
-                                    erlang:size(element(3, Key)) == Size
-                    end
-            end;
+    %% Construct a function to check start bounds...
+    StartFun = case StartTerm of
+                   undefined ->
+                       fun({KeyIndex, KeyField, _}) -> 
+                               {KeyIndex, KeyField} >= {Index, Field} 
+                       end;
+                   _ ->
+                       fun(Key) ->
+                               Key >= {Index, Field, StartTerm}
+                       end
+               end,
+
+    %% Construct a function to check end bounds...
+    EndFun = case EndTerm of
+                   undefined ->
+                       fun({KeyIndex, KeyField, _}) -> 
+                               {KeyIndex, KeyField} =< {Index, Field} 
+                       end;
+                   _ ->
+                       fun(Key) ->
+                               Key =< {Index, Field, EndTerm}
+                       end
+               end,
+
+    %% Possibly construct a function to check size. Return the final
+    %% filter function...
+    case Size of
+        all ->
+            fun(Key) -> StartFun(Key) andalso EndFun(Key) end;
         _ ->
-            case Size of
-                all ->
-                    fun(Key) -> Key >= {Index, Field, StartTerm}
-                                    andalso
-                                    Key =< {Index, Field, EndTerm}
-                    end;
-                _ ->
-                    fun(Key) -> Key >= {Index, Field, StartTerm}
-                                    andalso
-                                    Key =< {Index, Field, EndTerm}
-                                    andalso
-                                    erlang:size(element(3, Key)) == Size
-                    end
-            end
+            SizeFun = fun({_, _, KeyTerm}) -> erlang:size(KeyTerm) == Size end,
+            fun(Key) -> StartFun(Key) andalso EndFun(Key) andalso SizeFun(Key) end
     end.

--- a/src/mi_segment.erl
+++ b/src/mi_segment.erl
@@ -275,14 +275,14 @@ iterators(Index, Field, StartTerm, EndTerm, Size, Segment) ->
                  end,
 
     %% Find the Key containing the offset information we need
-    StartKey = {Index, Field, StartTerm},
+    StartKey = {Index, Field, StartTerm1},
     case get_offset_entry(StartKey, Segment) of
         {OffsetEntryKey, {BlockStart, _, _, _}} ->
             {ok, ReadAheadSize} = application:get_env(merge_index, segment_query_read_ahead_size),
             {ok, FH} = file:open(data_file(Segment), [read, raw, binary, {read_ahead, ReadAheadSize}]),
             file:position(FH, BlockStart),
             iterate_range_by_term(FH, OffsetEntryKey, Index, Field,
-                                  StartTerm, EndTerm, Size);
+                                  StartTerm1, EndTerm, Size);
         undefined ->
             [fun() -> eof end]
     end.


### PR DESCRIPTION
Update merge_index to accept 'undefined' on either end of a range query, telling the system to return all results in that direction.

Due to how offset tables are stored, 'undefined' will not match any terms smaller than -9223372036854775808 (-1 \* 2^16) when 'undefined' is used for the lower bound of the range query.
