### PR TITLE
More sane buffer conversion with better memory usage

### DIFF
--- a/include/merge_index.hrl
+++ b/include/merge_index.hrl
@@ -1,7 +1,3 @@
--define(PRINT(Var), error_logger:info_msg("DEBUG: ~p:~p~n~p~n  ~p~n", [?MODULE, ?LINE, ??Var, Var])).
--define(TIMEON, erlang:put(debug_timer, [now()|case erlang:get(debug_timer) == undefined of true -> []; false -> erlang:get(debug_timer) end])).
--define(TIMEOFF(Var, Count), io:format("~s :: ~p @ ~10.2fms (~10.2f total) : ~p : ~p~n", [string:copies(" ", length(erlang:get(debug_timer))), Count, (timer:now_diff(now(), hd(erlang:get(debug_timer)))/1000/(Count+1)),(timer:now_diff(now(), hd(erlang:get(debug_timer)))/1000), ??Var, Var]), erlang:put(debug_timer, tl(erlang:get(debug_timer)))).
-
 -record(segment,{root,
                  offsets_table,
                  size}).

--- a/src/mi_buffer.erl
+++ b/src/mi_buffer.erl
@@ -27,6 +27,7 @@
     new/1,
     filename/1,
     id/1,
+    exists/1,
     close_filehandle/1,
     delete/1,
     filesize/1,
@@ -78,6 +79,8 @@ filename(Buffer) -> Buffer#buffer.filename.
 
 id(#buffer{filename=Filename}) -> id(Filename);
 id(Filename) -> list_to_integer(tl(filename:extension(Filename))).
+
+exists(#buffer{table=Table}) -> ets:info(Table) /= undefined.
 
 delete(Buffer=#buffer{table=Table, filename=Filename}) ->
     ets:delete(Table),

--- a/src/mi_buffer.erl
+++ b/src/mi_buffer.erl
@@ -26,6 +26,7 @@
 -export([
     new/1,
     filename/1,
+    id/1,
     close_filehandle/1,
     delete/1,
     filesize/1,
@@ -73,8 +74,10 @@ open_inner(FH, Table, Filename) ->
             ok
     end.
 
-filename(Buffer) ->
-    Buffer#buffer.filename.
+filename(Buffer) -> Buffer#buffer.filename.
+
+id(#buffer{filename=Filename}) -> id(Filename);
+id(Filename) -> list_to_integer(tl(filename:extension(Filename))).
 
 delete(Buffer=#buffer{table=Table, filename=Filename}) ->
     ets:delete(Table),

--- a/src/mi_buffer_converter.erl
+++ b/src/mi_buffer_converter.erl
@@ -21,107 +21,45 @@
 %%
 %% -------------------------------------------------------------------
 
-%% This module is a supervisor and gen_sever rolled into one.  The
-%% supervisor's sole purpose is to monitor the one gen_server it owns,
-%% and attempt a couple of restarts, or blow up if restarts happen too
-%% fast.
-%%
-%% The supervisor is started by mi_server, and the gen_server alerts
-%% mi_server to its presence.  mi_server talks directly to the worker
-%% using the convert/3 function.  mi_server is linked to the supervisor,
-%% so it gets an EXIT message only after the gen_server has reached its
-%% max restart limit.
 -module(mi_buffer_converter).
-
-%-behaviour(supervisor). % not actually conflicting...
 -behaviour(gen_server).
 
 %% API
--export([start_link/2, convert/3]).
+-export([start_link/3, convert/3]).
 
 %% gen_server callbacks
--export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
+         code_change/3]).
 
-%% private callbacks
--export([start_worker/2]).
-
--record(state, {mi_server, mi_root}).
+-record(state, {server, root, buffer}).
 
 %%====================================================================
 %% API
 %%====================================================================
-%%--------------------------------------------------------------------
-%% Function: start_link() -> {ok,Pid} | ignore | {error,Error}
-%% Description: Starts the server
-%%--------------------------------------------------------------------
-start_link(MIServerPid, MIServerRoot) ->
-    supervisor:start_link(
-      ?MODULE, [supervisor, MIServerPid, MIServerRoot]).
 
-%% @private
-start_worker(MIServerPid, MIServerRoot) ->
-    gen_server:start_link(
-      ?MODULE, [gen_server, MIServerPid, MIServerRoot], []).
+start_link(Server, Root, Buffer) ->
+    gen_server:start_link(?MODULE, [Server, Root, Buffer], []).
 
-convert(undefined, _Root, _Buffer) ->
-    %% mi_server tried to convert a buffer before
-    %% it had a registered converter: ignore
-    ok;
-convert(Converter, Root, Buffer) ->
-    gen_server:cast(Converter, {convert, Root, Buffer}).
+convert(Server, Root, Buffer) ->
+    mi_buffer_converter_sup:start_child(Server, Root, Buffer).
 
 %%====================================================================
-%% gen_server callbacks
+%% Callbacks
 %%====================================================================
 
-%%--------------------------------------------------------------------
-%% Func: init(Args) -> {ok,  {SupFlags,  [ChildSpec]}} |
-%%                     ignore                          |
-%%                     {error, Reason}
-%% Description: Whenever a supervisor is started using 
-%% supervisor:start_link/[2,3], this function is called by the new process 
-%% to find out about restart strategy, maximum restart frequency and child 
-%% specifications.
-%%--------------------------------------------------------------------
-init([supervisor, MIServerPid, MIServerRoot]) ->
-    AChild = {buffer_converter_worker,
-              {mi_buffer_converter,start_worker,
-               [MIServerPid, MIServerRoot]},
-              permanent,2000,worker,[mi_buffer_converter]},
-    {ok,{{one_for_all,10,1}, [AChild]}};
-%%--------------------------------------------------------------------
-%% Function: init(Args) -> {ok, State} |
-%%                         {ok, State, Timeout} |
-%%                         ignore               |
-%%                         {stop, Reason}
-%% Description: Initiates the server
-%%--------------------------------------------------------------------
-init([gen_server, MIServerPid, MIServerRoot]) ->
-    mi_server:register_buffer_converter(MIServerPid, self()),
-    {ok, #state{mi_server=MIServerPid, mi_root=MIServerRoot}}.
+init([Server, Root, Buffer]) ->
+    link(Server),
+    {ok, #state{server=Server, root=Root, buffer=Buffer}, 0}.
 
-%%--------------------------------------------------------------------
-%% Function: %% handle_call(Request, From, State) -> {reply, Reply, State} |
-%%                                      {reply, Reply, State, Timeout} |
-%%                                      {noreply, State} |
-%%                                      {noreply, State, Timeout} |
-%%                                      {stop, Reason, Reply, State} |
-%%                                      {stop, Reason, State}
-%% Description: Handling call messages
-%%--------------------------------------------------------------------
-handle_call(_Request, _From, State) ->
-    Reply = ok,
-    {reply, Reply, State}.
+handle_call(_Msg, _From, State) ->
+    lager:error("Unexpected call ~p", [_Msg]),
+    {reply, error, State}.
 
-%%--------------------------------------------------------------------
-%% Function: handle_cast(Msg, State) -> {noreply, State} |
-%%                                      {noreply, State, Timeout} |
-%%                                      {stop, Reason, State}
-%% Description: Handling cast messages
-%%--------------------------------------------------------------------
-handle_cast({convert, Root, Buffer}, #state{mi_root=Root}=State) ->
-    %% Calculate the segment filename, open the segment, and convert.
+handle_cast(_Msg, State) ->
+    lager:error("Unexpected cast ~p", [_Msg]),
+    {noreply, State}.
+
+handle_info(timeout, #state{server=Server, root=Root, buffer=Buffer}=State) ->
     try
         SNum  = mi_server:get_id_number(mi_buffer:filename(Buffer)),
         SName = filename:join(Root, "segment." ++ integer_to_list(SNum)),
@@ -136,44 +74,18 @@ handle_cast({convert, Root, Buffer}, #state{mi_root=Root}=State) ->
         end,
         SegmentWO = mi_segment:open_write(SName),
         mi_segment:from_buffer(Buffer, SegmentWO),
-        mi_server:buffer_to_segment(State#state.mi_server, Buffer, SegmentWO),
-        {noreply, State}
+        mi_server:buffer_to_segment(Server, Buffer, SegmentWO),
+        {stop, normal, State}
     catch
         error:badarg ->
             error_logger:warning_msg("`convert` attempted to work with a"
                                      " nonexistent buffer, probably because"
                                      " drop was called~n"),
-            {noreply, State}
-    end;
-handle_cast(_Msg, State) ->
-    {noreply, State}.
+            {stop, buffer_dropped, State}
+    end.
 
-%%--------------------------------------------------------------------
-%% Function: handle_info(Info, State) -> {noreply, State} |
-%%                                       {noreply, State, Timeout} |
-%%                                       {stop, Reason, State}
-%% Description: Handling all non call/cast messages
-%%--------------------------------------------------------------------
-handle_info(_Info, State) ->
-    {noreply, State}.
-
-%%--------------------------------------------------------------------
-%% Function: terminate(Reason, State) -> void()
-%% Description: This function is called by a gen_server when it is about to
-%% terminate. It should be the opposite of Module:init/1 and do any necessary
-%% cleaning up. When it returns, the gen_server terminates with Reason.
-%% The return value is ignored.
-%%--------------------------------------------------------------------
 terminate(_Reason, _State) ->
     ok.
 
-%%--------------------------------------------------------------------
-%% Func: code_change(OldVsn, State, Extra) -> {ok, NewState}
-%% Description: Convert process state when code is changed
-%%--------------------------------------------------------------------
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
-
-%%--------------------------------------------------------------------
-%%% Internal functions
-%%--------------------------------------------------------------------

--- a/src/mi_buffer_converter.erl
+++ b/src/mi_buffer_converter.erl
@@ -80,7 +80,7 @@ handle_info(timeout, #state{server=Server, root=Root, buffer=Buffer}=State) ->
         error:badarg ->
             lager:warning("`convert` attempted to work with a"
                           " nonexistent buffer, probably because"
-                          " drop was called"),
+                          " drop was called ~p", [erlang:get_stacktrace()]),
             {stop, buffer_dropped, State}
     end.
 

--- a/src/mi_buffer_converter.erl
+++ b/src/mi_buffer_converter.erl
@@ -61,7 +61,7 @@ handle_cast(_Msg, State) ->
 
 handle_info(timeout, #state{server=Server, root=Root, buffer=Buffer}=State) ->
     try
-        SNum  = mi_server:get_id_number(mi_buffer:filename(Buffer)),
+        SNum  = mi_buffer:id(Buffer),
         SName = filename:join(Root, "segment." ++ integer_to_list(SNum)),
 
         case mi_server:has_deleteme_flag(SName) of

--- a/src/mi_buffer_converter_sup.erl
+++ b/src/mi_buffer_converter_sup.erl
@@ -31,7 +31,7 @@ start_child(Server, Root, Buffer) ->
     supervisor:start_child(mi_buffer_converter_sup, [Server, Root, Buffer]).
 
 init([]) ->
-    Spec = {undefined,
+    Spec = {ignored,
             {mi_buffer_converter, start_link, []},
-            temporary, 1000, worker, [mi_buffer_converter]},
+            transient, 1000, worker, [mi_buffer_converter]},
     {ok, {{simple_one_for_one, 10, 1}, [Spec]}}.

--- a/src/mi_buffer_converter_sup.erl
+++ b/src/mi_buffer_converter_sup.erl
@@ -17,32 +17,21 @@
 %% under the License.
 %%
 %% -------------------------------------------------------------------
-
--module(mi_sup).
+-module(mi_buffer_converter_sup).
 -behaviour(supervisor).
 
-%% API
--export([start_link/0]).
+-export([init/1,
+         start_link/0,
+         start_child/3]).
 
-%% Supervisor callbacks
--export([init/1]).
-
-%% Helper macro for declaring children of supervisor
--define(CHILD(I, Type), {I, {I, start_link, []}, permanent, 5000, Type, [I]}).
-
-%% ===================================================================
-%% API functions
-%% ===================================================================
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
-
-%% ===================================================================
-%% Supervisor callbacks
-%% ===================================================================
+start_child(Server, Root, Buffer) ->
+    supervisor:start_child(mi_buffer_converter_sup, [Server, Root, Buffer]).
 
 init([]) ->
-    Scheduler = ?CHILD(mi_scheduler, worker),
-    Converter = ?CHILD(mi_buffer_converter_sup, supervisor),
-
-    {ok, {{one_for_one, 5, 10}, [Converter, Scheduler]}}.
+    Spec = {undefined,
+            {mi_buffer_converter, start_link, []},
+            temporary, 1000, worker, [mi_buffer_converter]},
+    {ok, {{simple_one_for_one, 10, 1}, [Spec]}}.

--- a/src/mi_scheduler.erl
+++ b/src/mi_scheduler.erl
@@ -81,11 +81,11 @@ handle_call({schedule_compaction, Pid}, _From, #state { queue = Q } = State) ->
     end;
 
 handle_call(Event, _From, State) ->
-    ?PRINT({unhandled_call, Event}),
+    lager:error("unhandled_call ~p", [Event]),
     {reply, ok, State}.
 
 handle_cast(Msg, State) ->
-    ?PRINT({unhandled_cast, Msg}),
+    lager:error("unhandled_cast ~p", [Msg]),
     {noreply, State}.
 
 handle_info({worker_ready, WorkerPid}, #state { queue = Q } = State) ->
@@ -106,7 +106,7 @@ handle_info({'EXIT', WorkerPid, Reason}, #state { worker = WorkerPid } = State) 
     {noreply, NewState};
 
 handle_info(Info, State) ->
-    ?PRINT({unhandled_info, Info}),
+    lager:error("unhandled_info ~p", [Info]),
     {noreply, State}.
 
 terminate(_Reason, _State) ->

--- a/test/merge_index_tests.erl
+++ b/test/merge_index_tests.erl
@@ -42,10 +42,12 @@ prop_api_test_() ->
 prop_api() ->
     application:load(merge_index),
     application:start(sasl),
+    application:start(lager),
+
     %% Comment out following lines to see error reports...otherwise
     %% it's too much noise
     error_logger:delete_report_handler(sasl_report_tty_h),
-    error_logger:delete_report_handler(error_logger_tty_h),
+    lager:set_loglevel(lager_console_backend, critical),
 
     ?FORALL(Cmds, commands(?MODULE),
             ?TRAPEXIT(


### PR DESCRIPTION
az608 bz1065

Convert the awkward buffer->segment process to a more OTP compliant
simple_one_for_one supervisor.  To keep the previous behavior of only one
buffer at a time per mi_server I made use of a queue in the mi_server to
keep track of pending buffer conversions.

This reduces memory usage as it now completely avoids long-lived buffer
conversion processes.
