### PR TITLE
BZ1165 Recover from truncated buffers

### DIFF
--- a/src/mi_buffer.erl
+++ b/src/mi_buffer.erl
@@ -166,7 +166,7 @@ read_value(FH, Filename) ->
     end.
 
 log_truncation(Filename, Position) ->
-    error_logger:info_msg("Corrupted posting detected in ~s after reading ~w bytes, ignoring remainder.",
+    error_logger:warning_msg("Corrupted posting detected in ~s after reading ~w bytes, ignoring remainder.",
                           [Filename, Position]).
 
 write_to_file(FH, Terms) when is_list(Terms) ->

--- a/src/mi_buffer.erl
+++ b/src/mi_buffer.erl
@@ -57,17 +57,17 @@ new(Filename) ->
 
     %% Read into an ets table...
     Table = ets:new(buffer, [duplicate_bag, public]),
-    open_inner(FH, Table),
+    open_inner(FH, Table, Filename),
     {ok, Size} = file:position(FH, cur),
 
     %% Return the buffer.
     #buffer { filename=Filename, handle=FH, table=Table, size=Size }.
 
-open_inner(FH, Table) ->
-    case read_value(FH) of
+open_inner(FH, Table, Filename) ->
+    case read_value(FH, Filename) of
         {ok, Postings} ->
             write_to_ets(Table, Postings),
-            open_inner(FH, Table);
+            open_inner(FH, Table, Filename);
         eof ->
             ok
     end.
@@ -145,7 +145,7 @@ iterate_list([H|T]) ->
 %% Internal functions
 %% ===================================================================
 
-read_value(FH) ->
+read_value(FH, Filename) ->
     {ok, CurrPos} = file:position(FH, cur),
     case file:read(FH, 4) of
         {ok, <<Size:32/unsigned-integer>>} when Size > 0->
@@ -153,16 +153,21 @@ read_value(FH) ->
                 {ok, <<B:Size/binary>>} ->
                     {ok, binary_to_term(B)};
                 _ ->
+                    log_truncation(Filename, CurrPos),
                     file:position(FH, {bof, CurrPos}),
                     eof
             end;
         {ok, _Binary}  ->
+            log_truncation(Filename, CurrPos),
             file:position(FH, {bof, CurrPos}),
             eof;
         eof ->
             eof
     end.
 
+log_truncation(Filename, Position) ->
+    error_logger:info_msg("Corrupted posting detected in ~s after reading ~w bytes, ignoring remainder.",
+                          [Filename, Position]).
 
 write_to_file(FH, Terms) when is_list(Terms) ->
     %% Convert all values to binaries, count the bytes.


### PR DESCRIPTION
Pursuant to http://issues.basho.com/1165, this allows `mi_buffer` to recover data out of truncated buffer files.  The edge-cases covered are:
1. Short read of the 4-byte `Size` field.
2. Short read of t2b/b2t blob (shorter than `Size`).
3. `Size` field is 0.

When a truncation is detected, it will be logged to `error_logger`. The relevant test is `mi_buffer_test:prop_truncation_test/1`, which fills a buffer with some postings, truncates the file and then verifies that some postings can still be recovered from it.
