### PR TITLE
Convert to lager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 ebin
 .eunit
 doc
+deps

--- a/rebar.config
+++ b/rebar.config
@@ -1,2 +1,7 @@
 {cover_enabled, true}.
-{erl_opts, [debug_info]}.
+{erl_opts, [debug_info, {parse_transform, lager_transform}]}.
+
+{deps, [
+        {lager, "0.9.*",
+         {git, "git://github.com/basho/lager", {branch, "master"}}}
+       ]}.

--- a/src/mi_buffer.erl
+++ b/src/mi_buffer.erl
@@ -60,6 +60,7 @@ new(Filename) ->
     open_inner(FH, Table),
     {ok, Size} = file:position(FH, cur),
 
+    lager:info("opened buffer '~s'", [Filename]),
     %% Return the buffer.
     #buffer { filename=Filename, handle=FH, table=Table, size=Size }.
 
@@ -75,11 +76,12 @@ open_inner(FH, Table) ->
 filename(Buffer) ->
     Buffer#buffer.filename.
 
-delete(Buffer) ->
-    ets:delete(Buffer#buffer.table),
+delete(Buffer=#buffer{table=Table, filename=Filename}) ->
+    ets:delete(Table),
     close_filehandle(Buffer),
-    file:delete(Buffer#buffer.filename),
-    file:delete(Buffer#buffer.filename ++ ".deleted"),
+    file:delete(Filename),
+    file:delete(Filename ++ ".deleted"),
+    lager:info("deleted buffer '~s'", [Filename]),
     ok.
 
 close_filehandle(Buffer) ->

--- a/src/mi_buffer_converter.erl
+++ b/src/mi_buffer_converter.erl
@@ -140,9 +140,9 @@ handle_cast({convert, Root, Buffer}, #state{mi_root=Root}=State) ->
         {noreply, State}
     catch
         error:badarg ->
-            error_logger:warning_msg("`convert` attempted to work with a"
-                                     " nonexistent buffer, probably because"
-                                     " drop was called~n"),
+            lager:warning("`convert` attempted to work with a"
+                          " nonexistent buffer, probably because"
+                          " drop was called"),
             {noreply, State}
     end;
 handle_cast(_Msg, State) ->

--- a/src/mi_segment.erl
+++ b/src/mi_segment.erl
@@ -66,6 +66,7 @@ open_read(Root) ->
             {ok, FileInfo} = file:read_file_info(data_file(Root)),
 
             OffsetsTable = read_offsets(Root),
+            lager:info("opened segment '~s' for read", [Root]),
             #segment {
                        root=Root,
                        offsets_table=OffsetsTable,
@@ -86,6 +87,7 @@ open_write(Root) ->
             %% TODO: Do we really need to go through the trouble of writing empty files here?
             file:write_file(data_file(Root), <<"">>),
             file:write_file(offsets_file(Root), <<"">>),
+            lager:info("opened segment '~s' for write", [Root]),
             #segment {
                        root = Root,     
                        offsets_table = ets:new(segment_offsets, [ordered_set, public])


### PR DESCRIPTION
az629

Convert all logging to use lager. Also resurrected some logging that I removed
in commit `7c6d74f76b00abb8f5c7e46d999c75416967222d` as it is potentially
useful.
