### PR TITLE
AZ825 Inline Field Error

### DIFF
--- a/src/mi_buffer.erl
+++ b/src/mi_buffer.erl
@@ -130,7 +130,7 @@ iterator(Buffer) ->
 iterator(Index, Field, Term, Buffer) ->
     Table = Buffer#buffer.table,
     List1 = ets:lookup(Table, {Index, Field, Term}),
-    List2 = [{V,K, add_field_term(Field, Term, P)} || {_Key,V,K,P} <- List1],
+    List2 = [{V,K,P} || {_Key,V,K,P} <- List1],
     List3 = lists:sort(List2),
     fun() -> iterate_list(List3) end.
 
@@ -187,12 +187,6 @@ write_to_file(FH, Terms) when is_list(Terms) ->
 
 write_to_ets(Table, Postings) ->
     ets:insert(Table, Postings).
-
-add_field_term(Field, Term, Props) when is_list(Props) ->
-    [{Field, Term}|Props];
-add_field_term(_Field, _Term, Props) ->
-    Props.
-
 
 %% @private
 %% @doc Given and Index, Field, StartTerm, EndTerm, and Size, return a

--- a/src/mi_buffer.erl
+++ b/src/mi_buffer.erl
@@ -125,7 +125,7 @@ iterator(Buffer) ->
     List1 = lists:sort(ets:tab2list(Table)),
     List2 = [{I,F,T,V,K,P} || {{I,F,T},V,K,P} <- List1],
     fun() -> iterate_list(List2) end.
-    
+
 %% Return an iterator that traverses the values for a term in the buffer.
 iterator(Index, Field, Term, Buffer) ->
     Table = Buffer#buffer.table,
@@ -198,16 +198,16 @@ add_field_term(_Field, _Term, Props) ->
 %% @doc Given and Index, Field, StartTerm, EndTerm, and Size, return a
 %%      filter function that returns true if the provided Key (of
 %%      format {Index, Field, Term}) is within the acceptable range.
--spec gen_filter(merge_index:index(), merge_index:field(), 
-                 merge_index:mi_term(), merge_index:mi_term(), 
-                 merge_index:size()) -> 
+-spec gen_filter(merge_index:index(), merge_index:field(),
+                 merge_index:mi_term(), merge_index:mi_term(),
+                 merge_index:size()) ->
                         fun((merge_index:index(), merge_index:field(), merge_index:mi_term()) -> boolean()).
 gen_filter(Index, Field, StartTerm, EndTerm, Size) ->
     %% Construct a function to check start bounds...
     StartFun = case StartTerm of
                    undefined ->
-                       fun({KeyIndex, KeyField, _}) -> 
-                               {KeyIndex, KeyField} >= {Index, Field} 
+                       fun({KeyIndex, KeyField, _}) ->
+                               {KeyIndex, KeyField} >= {Index, Field}
                        end;
                    _ ->
                        fun(Key) ->
@@ -218,8 +218,8 @@ gen_filter(Index, Field, StartTerm, EndTerm, Size) ->
     %% Construct a function to check end bounds...
     EndFun = case EndTerm of
                    undefined ->
-                       fun({KeyIndex, KeyField, _}) -> 
-                               {KeyIndex, KeyField} =< {Index, Field} 
+                       fun({KeyIndex, KeyField, _}) ->
+                               {KeyIndex, KeyField} =< {Index, Field}
                        end;
                    _ ->
                        fun(Key) ->

--- a/src/mi_segment.erl
+++ b/src/mi_segment.erl
@@ -245,13 +245,7 @@ iterate_by_term(File, BaseKey, [{_, _, _, ValuesSize, _}|KeyInfoList], Key) ->
                     file:read(File, ValuesSize),
                     iterate_by_term(File, CurrKey, KeyInfoList, Key);
                 CurrKey == Key ->
-                    {_, Field, Term} = CurrKey,
-                    Transform =
-                        fun({V, K, P}) when is_list(P) ->
-                                {V, K, [{Field, Term}|P]};
-                           (Other) ->
-                                Other
-                        end,
+                    Transform = fun(X) -> X end,
                     WhenDone = fun(_) -> file:close(File), eof end,
                     fun() -> iterate_by_term_values(File, Transform, WhenDone) end;
                 CurrKey > Key ->
@@ -373,9 +367,6 @@ possibly_add_iterator({_, Field, Term}, Results, IteratorsAcc) ->
 %% Turn a list into an iterator.
 iterate_list(_, _, []) ->
     eof;
-iterate_list(Field, Term, [{V,K,P}|T]) when is_list(P) ->
-    NewH = {V, K, [{Field, Term}|P]},
-    {NewH, fun() -> iterate_list(Field, Term, T) end};
 iterate_list(Field, Term, [H|T]) ->
     {H, fun() -> iterate_list(Field, Term, T) end}.
 

--- a/src/mi_segment.erl
+++ b/src/mi_segment.erl
@@ -49,7 +49,7 @@
 
 
 %% MIN_VALUE is used during range searches. Numbers sort the smallest
-%% in Erlang (http://www.erlang.org/doc/reference_manual/expressions.html), 
+%% in Erlang (http://www.erlang.org/doc/reference_manual/expressions.html),
 %% so this is just a very small number.
 -define(MIN_VALUE, -9223372036854775808). %% -1 * (2^63)).
 
@@ -89,7 +89,7 @@ open_write(Root) ->
             file:write_file(offsets_file(Root), <<"">>),
             lager:info("opened segment '~s' for write", [Root]),
             #segment {
-                       root = Root,     
+                       root = Root,
                        offsets_table = ets:new(segment_offsets, [ordered_set, public])
                      }
     end.
@@ -120,7 +120,7 @@ info(Index, Field, Term, Segment) ->
     case get_offset_entry(Key, Segment) of
         {OffsetEntryKey, {_, Bloom, _, KeyInfoList}} ->
             case mi_bloom:is_element(Key, Bloom) of
-                true  -> 
+                true  ->
                     {_, _, OffsetEntryTerm} = OffsetEntryKey,
                     EditSig = mi_utils:edit_signature(OffsetEntryTerm, Term),
                     HashSig = mi_utils:hash_signature(Term),
@@ -128,12 +128,12 @@ info(Index, Field, Term, Segment) ->
                                 case EditSig == EditSig2 andalso HashSig == HashSig2 of
                                     true ->
                                         Acc + Count;
-                                    false -> 
+                                    false ->
                                         Acc
                                 end
                         end,
                     lists:foldl(F, 0, KeyInfoList);
-                false -> 
+                false ->
                     0
             end;
         _ ->
@@ -174,7 +174,7 @@ iterate_all_bytes_1(Key, [Result|Results], Rest) ->
     {{I,F,T,V,K,P}, fun() -> iterate_all_bytes_1(Key, Results, Rest) end};
 iterate_all_bytes_1(Key, [], Rest) ->
     iterate_all_bytes(Key, Rest).
-    
+
 %% @private Create an iterator over a filehandle starting at position
 %% 0 of the segment.
 iterate_all_filehandle(File, BaseKey, {key, ShrunkenKey}) ->
@@ -199,7 +199,7 @@ iterator(Index, Field, Term, Segment) ->
             %% If we're aiming for an exact match, then check the
             %% bloom filter.
             case mi_bloom:is_element(Key, Bloom) of
-                true -> 
+                true ->
                     {_, _, OffsetEntryTerm} = OffsetEntryKey,
                     EditSig = mi_utils:edit_signature(OffsetEntryTerm, Term),
                     HashSig = mi_utils:hash_signature(Term),
@@ -232,7 +232,7 @@ iterate_by_keyinfo(_, _, _, _, _, [], _) ->
 %% section we want.
 iterate_by_term(File, BaseKey, [{_, _, _, ValuesSize, _}|KeyInfoList], Key) ->
     %% Read the next entry in the segment file.  Value should be a
-    %% key, otherwise error. 
+    %% key, otherwise error.
     case read_seg_entry(File) of
         {key, ShrunkenKey} ->
             CurrKey = expand_key(BaseKey, ShrunkenKey),
@@ -240,7 +240,7 @@ iterate_by_term(File, BaseKey, [{_, _, _, ValuesSize, _}|KeyInfoList], Key) ->
             %% jumping. If it's the one we need, then iterate
             %% values. Otherwise, it's too big, so close the file and
             %% return.
-            if 
+            if
                 CurrKey < Key ->
                     file:read(File, ValuesSize),
                     iterate_by_term(File, CurrKey, KeyInfoList, Key);
@@ -267,7 +267,7 @@ iterate_by_term(File, BaseKey, [{_, _, _, ValuesSize, _}|KeyInfoList], Key) ->
 iterate_by_term(File, _, [], _) ->
     file:close(File),
     fun() -> eof end.
-    
+
 iterate_by_term_values(File, TransformFun, WhenDoneFun) ->
     %% Read the next value, expose as iterator.
     case read_seg_entry(File) of
@@ -323,7 +323,7 @@ iterate_range_by_term_1(File, BaseKey, Index, Field, StartTerm, EndTerm, Size,
             %% jumping. If it's in the range we need, then iterate
             %% values. Otherwise, it's too big, so close the file and
             %% return.
-            if 
+            if
                 CurrKey < {Index, Field, StartTerm} ->
                     iterate_range_by_term_1(File, CurrKey, Index, Field,
                                             StartTerm, EndTerm, Size,
@@ -369,7 +369,7 @@ possibly_add_iterator({_, Field, Term}, Results, IteratorsAcc) ->
     Results1 = lists:flatten(lists:reverse(Results)),
     Iterator = fun() -> iterate_list(Field, Term, Results1) end,
     [Iterator|IteratorsAcc].
-    
+
 %% Turn a list into an iterator.
 iterate_list(_, _, []) ->
     eof;
@@ -387,9 +387,9 @@ get_offset_entry(Key, Segment) ->
     case ets:lookup(Segment#segment.offsets_table, Key) of
         [] ->
             case ets:next(Segment#segment.offsets_table, Key) of
-                '$end_of_table' -> 
+                '$end_of_table' ->
                     undefined;
-                OffsetKey ->    
+                OffsetKey ->
                     %% Look up the offset information.
                     [{OffsetKey, Value}] = ets:lookup(Segment#segment.offsets_table, OffsetKey),
                     {OffsetKey, binary_to_term(Value)}

--- a/test/mi_buffer_tests.erl
+++ b/test/mi_buffer_tests.erl
@@ -74,7 +74,7 @@ check_range(Root, Entries, Range) ->
     {Index, Field, StartTerm} = Start,
     {Index, Field, EndTerm} = End,
 
-    L1 = [{V, K, [{F,T}|P]} || {{_, F, T}=IFT, V, K, P} <- Entries,
+    L1 = [{V, K, P} || {IFT, V, K, P} <- Entries,
                        IFT >= Start, IFT =< End],
 
     Itrs = mi_buffer:iterators(Index, Field, StartTerm, EndTerm, all, Buffer),

--- a/test/mi_segment_tests.erl
+++ b/test/mi_segment_tests.erl
@@ -106,7 +106,7 @@ check_range(Root, Entries, Range) ->
     Itrs = mi_segment:iterators(Index, Field, StartTerm, EndTerm, all, Segment),
     L1 = fold_iterators(Itrs, fun(Item, Acc0) -> [Item | Acc0] end, []),
 
-    L2 = [{V, K, [{Ff,Tt}|P]}
+    L2 = [{V, K, P}
           || {Ii, Ff, Tt, V, K, P} <- fold_iterator(mi_segment:iterator(Segment),
                                                     fun(I,A) -> [I|A] end, []),
              {Ii, Ff, Tt} >= Start, {Ii, Ff, Tt} =< End],
@@ -124,7 +124,7 @@ prop_iter_test(Root) ->
 check_iter(Root, Entries, IFT) ->
     {I, F, T} = IFT,
 
-    L1 = [{Value, Tstamp, [{Field,Term}|Props] } ||
+    L1 = [{Value, Tstamp, Props} ||
              {{Index, Field, Term, Value}, {Tstamp, Props}}
                  <- lists:foldl(fun common:unique_latest/2,
                                 [], lists:sort(Entries)),


### PR DESCRIPTION
Full description here: https://issues.basho.com/1240

Relies on the following pull requests:
- https://github.com/basho/riak/pull/92
- https://github.com/basho/riak_search/pull/90

In the 1.0 release, we modified merge_index to include a {Field, Term} entry in the metadata returned for each result. This was intended to be used in 2i and is the root cause of this bug. 2i does not use merge_index, and would not use this value anyway, so we can safely remove the extra {Field, Term} entry.

``` bash
# Install the search hook in the desired bucket...
bin/search-cmd install mybucket

# Run some queries. These both work.
bin/search-cmd search mybucket 'myvalue'
bin/search-cmd search mybucket 'myvalue' 'myvalue'

# Now, add data.
curl -X POST \
    -d "myvalue" \
    http://localhost:8098/riak/mybucket/mykey

# Run the queries again. The first one is fine, the second one fails.
bin/search-cmd search mybucket 'myvalue'
bin/search-cmd search mybucket 'myvalue' 'myvalue'
```
