### PR TITLE
Lower the log level of most messages so it's less spammy.

### DIFF
--- a/src/mi_buffer.erl
+++ b/src/mi_buffer.erl
@@ -62,7 +62,7 @@ new(Filename) ->
     open_inner(FH, Table, Filename),
     {ok, Size} = file:position(FH, cur),
 
-    lager:info("opened buffer '~s'", [Filename]),
+    lager:debug("opened buffer '~s'", [Filename]),
     %% Return the buffer.
     #buffer { filename=Filename, handle=FH, table=Table, size=Size }.
 
@@ -87,7 +87,7 @@ delete(Buffer=#buffer{table=Table, filename=Filename}) ->
     close_filehandle(Buffer),
     file:delete(Filename),
     file:delete(Filename ++ ".deleted"),
-    lager:info("deleted buffer '~s'", [Filename]),
+    lager:debug("deleted buffer '~s'", [Filename]),
     ok.
 
 close_filehandle(Buffer) ->

--- a/src/mi_segment.erl
+++ b/src/mi_segment.erl
@@ -66,7 +66,7 @@ open_read(Root) ->
             {ok, FileInfo} = file:read_file_info(data_file(Root)),
 
             OffsetsTable = read_offsets(Root),
-            lager:info("opened segment '~s' for read", [Root]),
+            lager:debug("opened segment '~s' for read", [Root]),
             #segment {
                        root=Root,
                        offsets_table=OffsetsTable,
@@ -87,7 +87,7 @@ open_write(Root) ->
             %% TODO: Do we really need to go through the trouble of writing empty files here?
             file:write_file(data_file(Root), <<"">>),
             file:write_file(offsets_file(Root), <<"">>),
-            lager:info("opened segment '~s' for write", [Root]),
+            lager:debug("opened segment '~s' for write", [Root]),
             #segment {
                        root = Root,
                        offsets_table = ets:new(segment_offsets, [ordered_set, public])

--- a/src/mi_server.erl
+++ b/src/mi_server.erl
@@ -126,7 +126,7 @@ stop(Server) ->
 %%%===================================================================
 
 init([Root]) ->
-    lager:info("loading merge_index '~s'", [Root]),
+    lager:debug("loading merge_index '~s'", [Root]),
     %% Seed the random generator...
     random:seed(now()),
     
@@ -151,7 +151,7 @@ init([Root]) ->
         to_convert = queue:new()
     },
 
-    lager:info("finished loading merge_index '~s' with rollover size ~p",
+    lager:debug("finished loading merge_index '~s' with rollover size ~p",
                [Root, State#state.buffer_rollover_size]),
     {ok, State}.
 
@@ -561,7 +561,7 @@ read_buf_and_seg(Root) ->
     F1 = fun(Filename) ->
         Basename = filename:basename(Filename, ?DELETEME_FLAG),
         Basename1 = filename:join(Root, Basename ++ ".*"),
-        lager:info("deleting '~s'", [Basename1]),
+        lager:debug("deleting '~s'", [Basename1]),
         [ok = file:delete(X) || X <- filelib:wildcard(Basename1)]
     end,
     [F1(X) || X <- filelib:wildcard(join(Root, "*.deleted"))],
@@ -584,7 +584,7 @@ read_buf_and_seg(Root) ->
 read_segments([], _Segments) -> [];
 read_segments([SName|Rest], Segments) ->
     %% Read the segment from disk...
-    lager:info("opening segment: '~s'", [SName]),
+    lager:debug("opening segment: '~s'", [SName]),
     Segment = mi_segment:open_read(SName),
     [Segment|read_segments(Rest, Segments)].
 
@@ -601,7 +601,7 @@ read_buffers(_Root, [{_BNum, BName}], NextID, Segments) ->
 
 read_buffers(Root, [{BNum, BName}|Rest], NextID, Segments) ->
     %% Multiple buffers exist... convert them into segments...
-    lager:info("converting buffer: '~s' to segment", [BName]),
+    lager:debug("converting buffer: '~s' to segment", [BName]),
     SName = join(Root, "segment." ++ integer_to_list(BNum)),
     set_deleteme_flag(SName),
     Buffer = mi_buffer:new(BName),


### PR DESCRIPTION
When starting up riak_search, merge_index tends to flood the console with lots of "opening" messages. This lowers the log severity level so that it will be less spammy.
