### PR TITLE
Fix iterator API (1.2 based)

### DIFF
--- a/src/mi_segment.erl
+++ b/src/mi_segment.erl
@@ -154,8 +154,11 @@ iterator(Segment) ->
         false ->
             %% Open a filehandle to the start of the segment.
             {ok, ReadAheadSize} = application:get_env(merge_index, segment_compact_read_ahead_size),
-            {ok, FH} = file:open(data_file(Segment), [read, raw, binary, {read_ahead, ReadAheadSize}]),
-            fun() -> iterate_all_filehandle(FH, undefined, undefined) end
+            fun() ->
+                    Opts = [read, raw, binary, {read_ahead, ReadAheadSize}],
+                    {ok, FH} = file:open(data_file(Segment), Opts),
+                    iterate_all_filehandle(FH, undefined, undefined)
+            end
     end.
 
 %% @private Create an iterator over a binary which represents the

--- a/src/mi_server.erl
+++ b/src/mi_server.erl
@@ -363,8 +363,10 @@ handle_call({iterator, Filter, DestPid, DestRef}, _From, State) ->
     SegmentItrs = [mi_segment:iterator(S) || S <- Segments],
     Itr = build_iterator_tree(BufferItrs ++ SegmentItrs),
 
-    Args = [Filter, DestPid, DestRef, Itr(), {[], 0}],
-    ItrPid = spawn_link(?MODULE, iterate2, Args),
+    ItrPid = spawn_link(
+               fun() ->
+                       iterate2(Filter, DestPid, DestRef, Itr(), {[],0})
+               end),
 
     NewPids = [ #stream_range{pid=ItrPid,
                               caller=DestPid,


### PR DESCRIPTION
Please see commit comments for details of the issue.

This fix is important because Riak Search handoff cannot complete without it and therefore cluster transitions will never finish.

There are no good work arounds for this issue but if you want handoff to complete you could try one of the following.
1. Increase the `segment_full_read_size`--but this only delays the inevitable and causes more memory usage.
2. Delete the merge index data--this means everything needs to be re-indexed.
