### PR TITLE
Allow runtime change of the segments-to-merge calculation

### DIFF
--- a/include/merge_index.hrl
+++ b/include/merge_index.hrl
@@ -1,5 +1,7 @@
 -record(segment,{root,
                  offsets_table,
                  size}).
+-type segment() :: #segment{}.
+-type segments() :: [segment()].
 
 

--- a/src/merge_index.app.src
+++ b/src/merge_index.app.src
@@ -11,6 +11,7 @@
             {buffer_rollover_size, 1048576},
             {buffer_delayed_write_size, 524288},
             {buffer_delayed_write_ms, 2000},
+            {compact_mod_fun, {mi_segment, segments_to_merge}},
             {max_compact_segments, 20},
             {segment_query_read_ahead_size, 65536},
             {segment_compact_read_ahead_size, 5242880},


### PR DESCRIPTION
The default calculation which determines the segments to merge is
easily skewed since it relies on the mean average.  This especially
hurts given automatic compaction is driven solely by buffer rollovers,
thus guarenteeing skew (because the new segments will always be much
smaller than old segments).

This change will allow a user to change the calculating function at
runtime.  This could be useful in production, allowing the ability to
swap in more agressive algorithms temporarily to help free up disk
space and memory.
