### PR TITLE
Remove the delayed_write option

### DIFF
--- a/src/mi_buffer.erl
+++ b/src/mi_buffer.erl
@@ -51,11 +51,7 @@
 new(Filename) ->
     %% Open the existing buffer file...
     filelib:ensure_dir(Filename),
-    {ok, DelayedWriteSize} = application:get_env(merge_index, buffer_delayed_write_size),
-    {ok, DelayedWriteMS} = application:get_env(merge_index, buffer_delayed_write_ms),
-    FuzzedWriteSize = trunc(mi_utils:fuzz(DelayedWriteSize, 0.1)),
-    FuzzedWriteMS = trunc(mi_utils:fuzz(DelayedWriteMS, 0.1)),
-    {ok, FH} = file:open(Filename, [read, write, raw, binary, {delayed_write, FuzzedWriteSize, FuzzedWriteMS}]),
+    {ok, FH} = file:open(Filename, [read, write, raw, binary]),
 
     %% Read into an ets table...
     Table = ets:new(buffer, [duplicate_bag, public]),

--- a/src/mi_segment_writer.erl
+++ b/src/mi_segment_writer.erl
@@ -66,9 +66,7 @@
 
 from_iterator(Iterator, Segment) ->
     %% Open the data file...
-    {ok, DelayedWriteSize} = application:get_env(merge_index, segment_delayed_write_size),
-    {ok, DelayedWriteMS} = application:get_env(merge_index, segment_delayed_write_ms),
-    {ok, DataFile} = file:open(mi_segment:data_file(Segment), [write, raw, binary, {delayed_write, DelayedWriteSize, DelayedWriteMS}]),
+    {ok, DataFile} = file:open(mi_segment:data_file(Segment), [write, raw, binary]),
 
     W = #writer {
       data_file=DataFile,


### PR DESCRIPTION
Don't use the delayed_write option when opening a file.  This option
is known to cause corruption issues in Erlang 15x.  It is fixed in
16B01 but currently Riak must run on 15B01, thus the VM cannot simply
be upgraded.

This patch is being made in direct relation to a customer having
buffer corruption issues when the machine is under heavy load.  I was
able to reproduce easily using an underpowered centos VM running on
virtual box.
